### PR TITLE
fixes spl system program  invalid bytes issue

### DIFF
--- a/solana-program-library/system-program/Makefile
+++ b/solana-program-library/system-program/Makefile
@@ -6,7 +6,7 @@ build:
 
 .PHONY: stream
 stream: build
-	substreams run -e $(ENDPOINT) substreams.yaml map_block -s 279312392 -t +1
+	substreams run -e $(ENDPOINT) substreams.yaml map_block -s 263852688 -t +1
 
 .PHONY: protogen
 protogen:

--- a/solana-program-library/system-program/src/instructions/parser.rs
+++ b/solana-program-library/system-program/src/instructions/parser.rs
@@ -6,6 +6,7 @@ use borsh::BorshDeserialize;
 use bytes::Buf;
 
 use super::structs::{CreateAccountLayout, CreateAccountWithSeedLayout};
+use substreams::log;
 
 const CREATE_ACCOUNT_DISCRIMINATOR: u32 = 0;
 const CREATE_ACCOUNT_WITH_SEED_DISCRIMINATOR: u32 = 3;
@@ -33,8 +34,10 @@ pub fn parse_instruction(bytes_stream: Vec<u8>) -> Instruction {
             }
             CREATE_ACCOUNT_WITH_SEED_DISCRIMINATOR => {
                 result.instructionType = "CreateAccountWithSeed".to_string();
-                result.createAccountWithSeed =
-                    CreateAccountWithSeedLayout::deserialize(rest_bytes).unwrap();
+                match CreateAccountWithSeedLayout::deserialize(rest_bytes) {
+                    Ok(layout) => result.createAccountWithSeed = layout,
+                    Err(e) => log::info!("Deserialization error: {:?}", rest_bytes),
+                }
             }
             _ => {}
         }

--- a/solana-program-library/system-program/substreams.yaml
+++ b/solana-program-library/system-program/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
-  name: 'tl_solana_programs_system_program_1_0_1'
-  version: v1.0.1
+  name: 'tl_solana_programs_system_program_1_0_2'
+  version: v1.0.2
 
 protobuf:
   files:


### PR DESCRIPTION
These are the bytes not able to parse via `CreateAccountWithSeedLayout::deserialize(rest_bytes)`

```
----------- BLOCK #263,852,688 (6kqyzFS7yfj9rJNdQ7oWxivUkwC3fEwd6NsbAGgzT2ty) ---------------
map_block: log: Deserialization error: [189, 22, 52, 124, 240, 29, 31, 0, 0, 0, 0, 0, 165, 0, 0, 0, 0, 0, 0, 0, 6, 221, 246, 225, 215, 101, 161, 147, 217, 203, 225, 70, 206, 235, 121, 172, 28, 180, 133, 237, 95, 91, 55, 145, 58, 140, 245, 133, 126, 255, 0, 169]

map_block: log: Deserialization error: [191, 189, 113, 70, 64, 132, 190, 4, 0, 0, 0, 0, 44, 44, 0, 0, 0, 0, 0, 0, 13, 7, 81, 168, 40, 45, 166, 19, 5, 254, 41, 156, 55, 185, 152, 229, 132, 113, 219, 17, 53, 3, 115, 16, 248, 190, 16, 69, 166, 10, 246, 238]

map_block: log: Deserialization error: [191, 189, 67, 123, 64, 15, 20, 6, 0, 0, 0, 0, 188, 56, 0, 0, 0, 0, 0, 0, 13, 7, 81, 168, 40, 45, 166, 19, 5, 254, 41, 156, 55, 185, 152, 229, 132, 113, 219, 17, 53, 3, 115, 16, 248, 190, 16, 69, 166, 10, 246, 238]
```
Generating this error 

```
ERRO (cli) application shutdown unexpectedly, quitting: stream invalid: rpc error: code = InvalidArgument desc = rpc error: code = InvalidArgument desc = step new irr: handler step new: execute modules: applying executor results "map_block" on block 263852688: execute: maps wasm call: block 263852688: module "map_block": general wasm execution panicked: wasm execution failed deterministically: panic in the wasm: "called `Result::unwrap()` on an `Err` value: Custom { kind: InvalidData, error: \"incomplete utf-8 byte sequence from index 4\" }" at src/instructions/parser.rs:37:74

```